### PR TITLE
Paragraph text can now explicitly be spanned

### DIFF
--- a/library/src/main/java/ru/noties/markwon/SpannableFactory.java
+++ b/library/src/main/java/ru/noties/markwon/SpannableFactory.java
@@ -57,6 +57,9 @@ public interface SpannableFactory {
             boolean isOdd);
 
     @Nullable
+    Object paragraph(boolean inTightList);
+
+    @Nullable
     Object image(
             @NonNull SpannableTheme theme,
             @NonNull String destination,

--- a/library/src/main/java/ru/noties/markwon/SpannableFactoryDef.java
+++ b/library/src/main/java/ru/noties/markwon/SpannableFactoryDef.java
@@ -105,6 +105,12 @@ public class SpannableFactoryDef implements SpannableFactory {
 
     @Nullable
     @Override
+    public Object paragraph(boolean inTightList) {
+        return null;
+    }
+
+    @Nullable
+    @Override
     public Object image(@NonNull SpannableTheme theme, @NonNull String destination, @NonNull AsyncDrawable.Loader loader, @NonNull ImageSizeResolver imageSizeResolver, @Nullable ImageSize imageSize, boolean replacementTextIsLink) {
         return new AsyncDrawableSpan(
                 theme,

--- a/library/src/main/java/ru/noties/markwon/renderer/SpannableMarkdownVisitor.java
+++ b/library/src/main/java/ru/noties/markwon/renderer/SpannableMarkdownVisitor.java
@@ -380,14 +380,15 @@ public class SpannableMarkdownVisitor extends AbstractVisitor {
 
     @Override
     public void visit(Paragraph paragraph) {
-
         final boolean inTightList = isInTightList(paragraph);
 
         if (!inTightList) {
             newLine();
         }
 
+        final int length = builder.length();
         visitChildren(paragraph);
+        setSpan(length, factory.paragraph(inTightList));
 
         if (!inTightList) {
             newLine();


### PR DESCRIPTION
Background:
Consumers of the library may for instance want line spacing for the
paragraph text but TextView's `lineSpacingMultiplier` and/or
`lineSpacingExtra` apply line spacing to all lines.

With this change, paragraphs may explicitly be spanned with a paragraph
affecting span such as `LineHeightSpan` while the other tags
(e.g. headings) may be kept unaffected.