### PR TITLE
Introduced a "copy" builder

### DIFF
--- a/markwon/src/main/java/ru/noties/markwon/SpannableConfiguration.java
+++ b/markwon/src/main/java/ru/noties/markwon/SpannableConfiguration.java
@@ -51,6 +51,14 @@ public class SpannableConfiguration {
         this.htmlAllowNonClosedTags = builder.htmlAllowNonClosedTags;
     }
 
+    /**
+     * Returns a new builder based on this configuration
+     */
+    @NonNull
+    public Builder newBuilder(@NonNull Context context) {
+        return new Builder(context, this);
+    }
+
     @NonNull
     public SpannableTheme theme() {
         return theme;
@@ -136,6 +144,21 @@ public class SpannableConfiguration {
 
         Builder(@NonNull Context context) {
             this.context = context;
+        }
+
+        Builder(@NonNull Context context, @NonNull SpannableConfiguration configuration) {
+            this(context);
+            this.theme = configuration.theme;
+            this.asyncDrawableLoader = configuration.asyncDrawableLoader;
+            this.syntaxHighlight = configuration.syntaxHighlight;
+            this.linkResolver = configuration.linkResolver;
+            this.urlProcessor = configuration.urlProcessor;
+            this.imageSizeResolver = configuration.imageSizeResolver;
+            this.factory = configuration.factory;
+            this.softBreakAddsNewLine = configuration.softBreakAddsNewLine;
+            this.htmlParser = configuration.htmlParser;
+            this.htmlRenderer = configuration.htmlRenderer;
+            this.htmlAllowNonClosedTags = configuration.htmlAllowNonClosedTags;
         }
 
         @NonNull

--- a/markwon/src/test/java/ru/noties/markwon/renderer/SpannableConfigurationTest.java
+++ b/markwon/src/test/java/ru/noties/markwon/renderer/SpannableConfigurationTest.java
@@ -1,0 +1,52 @@
+package ru.noties.markwon.renderer;
+
+import org.junit.Test;
+
+import ru.noties.markwon.SpannableConfiguration;
+import ru.noties.markwon.SpannableFactory;
+import ru.noties.markwon.SyntaxHighlight;
+import ru.noties.markwon.UrlProcessor;
+import ru.noties.markwon.html.api.MarkwonHtmlParser;
+import ru.noties.markwon.renderer.html2.MarkwonHtmlRenderer;
+import ru.noties.markwon.spans.AsyncDrawable;
+import ru.noties.markwon.spans.LinkSpan;
+import ru.noties.markwon.spans.SpannableTheme;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+public class SpannableConfigurationTest {
+
+    @Test
+    public void testNewBuilder() {
+        final SpannableConfiguration configuration = SpannableConfiguration
+                .builder(null)
+                .theme(mock(SpannableTheme.class))
+                .asyncDrawableLoader(mock(AsyncDrawable.Loader.class))
+                .syntaxHighlight(mock(SyntaxHighlight.class))
+                .linkResolver(mock(LinkSpan.Resolver.class))
+                .urlProcessor(mock(UrlProcessor.class))
+                .imageSizeResolver(mock(ImageSizeResolver.class))
+                .factory(mock(SpannableFactory.class))
+                .softBreakAddsNewLine(true)
+                .htmlParser(mock(MarkwonHtmlParser.class))
+                .htmlRenderer(mock(MarkwonHtmlRenderer.class))
+                .htmlAllowNonClosedTags(true)
+                .build();
+
+        final SpannableConfiguration newConfiguration = configuration
+                .newBuilder(null)
+                .build();
+
+        assertEquals(configuration.theme(), newConfiguration.theme());
+        assertEquals(configuration.asyncDrawableLoader(), newConfiguration.asyncDrawableLoader());
+        assertEquals(configuration.syntaxHighlight(), newConfiguration.syntaxHighlight());
+        assertEquals(configuration.linkResolver(), newConfiguration.linkResolver());
+        assertEquals(configuration.urlProcessor(), newConfiguration.urlProcessor());
+        assertEquals(configuration.imageSizeResolver(), newConfiguration.imageSizeResolver());
+        assertEquals(configuration.factory(), newConfiguration.factory());
+        assertEquals(configuration.softBreakAddsNewLine(), newConfiguration.softBreakAddsNewLine());
+        assertEquals(configuration.htmlParser(), newConfiguration.htmlParser());
+        assertEquals(configuration.htmlRenderer(), newConfiguration.htmlRenderer());
+        assertEquals(configuration.htmlAllowNonClosedTags(), newConfiguration.htmlAllowNonClosedTags());
+    }
+}


### PR DESCRIPTION
Rationale:
Sometimes there is a need to override just one of the configurations while retaining the other configurations. A future use-case for this will be in MarkwonViewHelper.