### PR TITLE
Extend task list parsing

### DIFF
--- a/markwon/src/main/java/ru/noties/markwon/tasklist/TaskListBlockParser.java
+++ b/markwon/src/main/java/ru/noties/markwon/tasklist/TaskListBlockParser.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 @SuppressWarnings("WeakerAccess")
 class TaskListBlockParser extends AbstractBlockParser {
 
-    private static final Pattern PATTERN = Pattern.compile("\\s*-\\s+\\[(x|X|\\s)\\]\\s+(.*)");
+    private static final Pattern PATTERN = Pattern.compile("\\s*[-*+]\\s+\\[(x|X|\\s)\\]\\s+(.*)");
 
     private final TaskListBlock block = new TaskListBlock();
 

--- a/markwon/src/main/java/ru/noties/markwon/tasklist/TaskListBlockParser.java
+++ b/markwon/src/main/java/ru/noties/markwon/tasklist/TaskListBlockParser.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 @SuppressWarnings("WeakerAccess")
 class TaskListBlockParser extends AbstractBlockParser {
 
-    private static final Pattern PATTERN = Pattern.compile("\\s*[-*+]\\s+\\[(x|X|\\s)\\]\\s+(.*)");
+    private static final Pattern PATTERN = Pattern.compile("\\s*([-*+]|\\d+[.)])\\s+\\[(x|X|\\s)]\\s+(.*)");
 
     private final TaskListBlock block = new TaskListBlock();
 
@@ -88,9 +88,9 @@ class TaskListBlockParser extends AbstractBlockParser {
                 continue;
             }
             listItem = new TaskListItem()
-                    .done(isDone(matcher.group(1)))
+                    .done(isDone(matcher.group(2)))
                     .indent(item.indent / 2);
-            inlineParser.parse(matcher.group(2), listItem);
+            inlineParser.parse(matcher.group(3), listItem);
             block.appendChild(listItem);
         }
     }

--- a/markwon/src/main/java/ru/noties/markwon/tasklist/TaskListBlockParser.java
+++ b/markwon/src/main/java/ru/noties/markwon/tasklist/TaskListBlockParser.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 @SuppressWarnings("WeakerAccess")
 class TaskListBlockParser extends AbstractBlockParser {
 
-    private static final Pattern PATTERN = Pattern.compile("\\s*([-*+]|\\d+[.)])\\s+\\[(x|X|\\s)]\\s+(.*)");
+    private static final Pattern PATTERN = Pattern.compile("\\s*([-*+]|\\d{1,9}[.)])\\s+\\[(x|X|\\s)]\\s+(.*)");
 
     private final TaskListBlock block = new TaskListBlock();
 

--- a/markwon/src/test/resources/tests/task-list.yaml
+++ b/markwon/src/test/resources/tests/task-list.yaml
@@ -8,6 +8,8 @@ input: |-
   + [ ] First plus
   + [x] Second plus
   + [X] Third plus
+  1. [x] Number with dot
+  3) [ ] Number
 
 output:
   - task-list: "First"
@@ -45,3 +47,11 @@ output:
   - task-list: "Third plus"
     blockIdent: 1
     done: true
+  - text: "\n"
+  - task-list: "Number with dot"
+    blockIdent: 1
+    done: true
+  - text: "\n"
+  - task-list: "Number"
+    blockIdent: 1
+    done: false

--- a/markwon/src/test/resources/tests/task-list.yaml
+++ b/markwon/src/test/resources/tests/task-list.yaml
@@ -1,0 +1,47 @@
+input: |-
+  - [ ] First
+  - [x] Second
+  - [X] Third
+  * [ ] First star
+  * [x] Second star
+  * [X] Third star
+  + [ ] First plus
+  + [x] Second plus
+  + [X] Third plus
+
+output:
+  - task-list: "First"
+    blockIdent: 1
+    done: false
+  - text: "\n"
+  - task-list: "Second"
+    blockIdent: 1
+    done: true
+  - text: "\n"
+  - task-list: "Third"
+    blockIdent: 1
+    done: true
+  - text: "\n"
+  - task-list: "First star"
+    blockIdent: 1
+    done: false
+  - text: "\n"
+  - task-list: "Second star"
+    blockIdent: 1
+    done: true
+  - text: "\n"
+  - task-list: "Third star"
+    blockIdent: 1
+    done: true
+  - text: "\n"
+  - task-list: "First plus"
+    blockIdent: 1
+    done: false
+  - text: "\n"
+  - task-list: "Second plus"
+    blockIdent: 1
+    done: true
+  - text: "\n"
+  - task-list: "Third plus"
+    blockIdent: 1
+    done: true


### PR DESCRIPTION
This pull request updates task list parser to also handle task list items that start with `*`, `+` symbols or numbers.

___

According to [GitHub Flavored Markdown Spec](https://github.github.com/gfm/#task-list-items-extension-) for task list items:
> A task list item is a list item where the first block in it is a paragraph which begins with a task list item marker and at least one whitespace character before any other content.

Which means that task list should be valid for [all](https://github.github.com/gfm/#list-marker) of the markers used for lists. This includes:

- a `-`, `+`, or `*` character.
- a sequence of 1–9 arabic digits (`0-9`), followed by either a `.` character or a `)` character.