### PR TITLE
Allow LinkifyPlugin to use LinkifyCompat through config

### DIFF
--- a/markwon-linkify/build.gradle
+++ b/markwon-linkify/build.gradle
@@ -14,6 +14,12 @@ android {
 }
 
 dependencies {
+    deps.with {
+        // To use LinkifyCompat
+        // note that this dependency must be added on a client side explicitly
+        compileOnly it['x-core']
+    }
+
     api project(':markwon-core')
 }
 

--- a/markwon-linkify/src/main/java/io/noties/markwon/linkify/LinkifyPlugin.java
+++ b/markwon-linkify/src/main/java/io/noties/markwon/linkify/LinkifyPlugin.java
@@ -144,7 +144,7 @@ public class LinkifyPlugin extends AbstractMarkwonPlugin {
         }
 
         @Override
-        protected boolean addLinks(@NonNull Spannable text, int mask) {
+        protected boolean addLinks(@NonNull Spannable text, @LinkifyMask int mask) {
             return LinkifyCompat.addLinks(text, mask);
         }
     }

--- a/markwon-linkify/src/main/java/io/noties/markwon/linkify/LinkifyPlugin.java
+++ b/markwon-linkify/src/main/java/io/noties/markwon/linkify/LinkifyPlugin.java
@@ -38,6 +38,11 @@ public class LinkifyPlugin extends AbstractMarkwonPlugin {
         return create(false);
     }
 
+    /**
+     * @param useCompat If true, use {@link LinkifyCompat} to handle links.
+     *                  Note that the {@link LinkifyCompat} depends on androidx.core:core,
+     *                  the dependency must be added on a client side explicitly.
+     */
     @NonNull
     public static LinkifyPlugin create(boolean useCompat) {
         return create(Linkify.EMAIL_ADDRESSES | Linkify.PHONE_NUMBERS | Linkify.WEB_URLS, useCompat);
@@ -48,6 +53,11 @@ public class LinkifyPlugin extends AbstractMarkwonPlugin {
         return new LinkifyPlugin(mask, false);
     }
 
+    /**
+     * @param useCompat If true, use {@link LinkifyCompat} to handle links.
+     *                  Note that the {@link LinkifyCompat} depends on androidx.core:core,
+     *                  the dependency must be added on a client side explicitly.
+     */
     @NonNull
     public static LinkifyPlugin create(@LinkifyMask int mask, boolean useCompat) {
         return new LinkifyPlugin(mask, useCompat);

--- a/markwon-linkify/src/main/java/io/noties/markwon/linkify/LinkifyPlugin.java
+++ b/markwon-linkify/src/main/java/io/noties/markwon/linkify/LinkifyPlugin.java
@@ -77,7 +77,13 @@ public class LinkifyPlugin extends AbstractMarkwonPlugin {
         registry.require(CorePlugin.class, new Action<CorePlugin>() {
             @Override
             public void apply(@NonNull CorePlugin corePlugin) {
-                corePlugin.addOnTextAddedListener(new LinkifyTextAddedListener(mask, useCompat));
+                final LinkifyTextAddedListener listener;
+                if (useCompat) {
+                    listener = new LinkifyCompatTextAddedListener(mask);
+                } else {
+                    listener = new LinkifyTextAddedListener(mask);
+                }
+                corePlugin.addOnTextAddedListener(listener);
             }
         });
     }
@@ -85,11 +91,9 @@ public class LinkifyPlugin extends AbstractMarkwonPlugin {
     private static class LinkifyTextAddedListener implements CorePlugin.OnTextAddedListener {
 
         private final int mask;
-        private final boolean useCompat;
 
-        LinkifyTextAddedListener(int mask, boolean useCompat) {
+        LinkifyTextAddedListener(int mask) {
             this.mask = mask;
-            this.useCompat = useCompat;
         }
 
         @Override
@@ -128,12 +132,20 @@ public class LinkifyPlugin extends AbstractMarkwonPlugin {
             }
         }
 
-        private boolean addLinks(@NonNull Spannable text, @LinkifyMask int mask) {
-            if (useCompat) {
-                return LinkifyCompat.addLinks(text, mask);
-            } else {
-                return Linkify.addLinks(text, mask);
-            }
+        protected boolean addLinks(@NonNull Spannable text, @LinkifyMask int mask) {
+            return Linkify.addLinks(text, mask);
+        }
+    }
+
+    private static class LinkifyCompatTextAddedListener extends LinkifyTextAddedListener {
+
+        LinkifyCompatTextAddedListener(int mask) {
+            super(mask);
+        }
+
+        @Override
+        protected boolean addLinks(@NonNull Spannable text, int mask) {
+            return LinkifyCompat.addLinks(text, mask);
         }
     }
 }


### PR DESCRIPTION
Add a `useCompat` parameter to the `LinkifyPlugin#create(...)` methods. If this parameter is `true`, we will use `LinkifyCompat` to handle links.

Note that the `LinkifyCompat` depends on _androidx.core:core_, we use `compileOnly` to introduce it, so the dependency must be added on a client side explicitly.

Resolve #201.
