### PR TITLE
Fix DexGuard optimization issue

### DIFF
--- a/markwon-html/src/main/java/io/noties/markwon/html/tag/StrikeHandler.java
+++ b/markwon-html/src/main/java/io/noties/markwon/html/tag/StrikeHandler.java
@@ -25,7 +25,7 @@ public class StrikeHandler extends TagHandler {
     static {
         boolean hasMarkdownImplementation;
         try {
-            org.commonmark.ext.gfm.strikethrough.Strikethrough.class.getName();
+            Class.forName("org.commonmark.ext.gfm.strikethrough.Strikethrough");
             hasMarkdownImplementation = true;
         } catch (Throwable t) {
             hasMarkdownImplementation = false;


### PR DESCRIPTION
We had an issue with Markwon and [DexGuard](https://www.guardsquare.com/en/products/dexguard). 
DexGuard does some kind of optimization that removes the try/catch in the static initializer. This causes the `NoClassDefFoundError` to be propagated outside causing a crash, when clients don't have `commonmark-ext-gfm-strikethrough` as a dependency.

Using `Class.forName` at line 28 fixes the issue.

We added `commonmark-ext-gfm-strikethrough` to our dependencies as a temporary fix, but this PR should be the real fix.