### PR TITLE
Update Coil Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ ext {
             'dagger'                  : "com.google.dagger:dagger:$daggerVersion",
             'picasso'                 : 'com.squareup.picasso:picasso:2.71828',
             'glide'                   : 'com.github.bumptech.glide:glide:4.9.0',
-            'coil'                    : 'io.coil-kt:coil:0.8.0'
+            'coil'                    : 'io.coil-kt:coil:0.10.1'
     ]
 
     deps['annotationProcessor'] = [

--- a/markwon-image-coil/src/main/java/io/noties/markwon/image/coil/CoilImagesPlugin.java
+++ b/markwon-image-coil/src/main/java/io/noties/markwon/image/coil/CoilImagesPlugin.java
@@ -15,7 +15,6 @@ import java.util.Map;
 
 import coil.Coil;
 import coil.ImageLoader;
-import coil.api.ImageLoaders;
 import coil.request.LoadRequest;
 import coil.request.RequestDisposable;
 import coil.target.Target;
@@ -48,7 +47,7 @@ public class CoilImagesPlugin extends AbstractMarkwonPlugin {
             @NonNull
             @Override
             public LoadRequest load(@NonNull AsyncDrawable drawable) {
-                return ImageLoaders.newLoadBuilder(Coil.loader(), context)
+                return LoadRequest.builder(context)
                         .data(drawable.getDestination())
                         .build();
             }
@@ -57,7 +56,7 @@ public class CoilImagesPlugin extends AbstractMarkwonPlugin {
             public void cancel(@NonNull RequestDisposable disposable) {
                 disposable.dispose();
             }
-        }, Coil.loader());
+        }, Coil.imageLoader(context));
     }
 
     @NonNull
@@ -67,7 +66,7 @@ public class CoilImagesPlugin extends AbstractMarkwonPlugin {
             @NonNull
             @Override
             public LoadRequest load(@NonNull AsyncDrawable drawable) {
-                return ImageLoaders.newLoadBuilder(imageLoader, context)
+                return LoadRequest.builder(context)
                         .data(drawable.getDestination())
                         .build();
             }

--- a/markwon-image-coil/src/main/java/io/noties/markwon/image/coil/CoilImagesPlugin.java
+++ b/markwon-image-coil/src/main/java/io/noties/markwon/image/coil/CoilImagesPlugin.java
@@ -128,7 +128,7 @@ public class CoilImagesPlugin extends AbstractMarkwonPlugin {
             LoadRequest request = coilStore.load(drawable).newBuilder()
                     .target(target)
                     .build();
-            RequestDisposable disposable = imageLoader.load(request);
+            RequestDisposable disposable = imageLoader.execute(request);
             cache.put(drawable, disposable);
         }
 


### PR DESCRIPTION
This bumps the `markwon-images-coil` artifact to use [Coil 0.10.1](https://github.com/coil-kt/coil/releases/tag/0.10.1). Main updates include replacing deprecated APIs.