### PR TITLE
Use singleton coil instance in recycler view sample to reproduce image loading issue on second view

### DIFF
--- a/app-sample/src/main/java/io/noties/markwon/app/samples/image/CoilRecyclerViewSample.kt
+++ b/app-sample/src/main/java/io/noties/markwon/app/samples/image/CoilRecyclerViewSample.kt
@@ -1,6 +1,7 @@
 package io.noties.markwon.app.samples.image
 
 import androidx.recyclerview.widget.LinearLayoutManager
+import coil.Coil
 import coil.ImageLoader
 import coil.request.LoadRequest
 import coil.request.RequestDisposable
@@ -66,11 +67,7 @@ class CoilRecyclerViewSample : MarkwonRecyclerViewSample() {
             disposable.dispose()
           }
         },
-        ImageLoader.Builder(context)
-          .okHttpClient(OkHttpClient())
-          // this line of code makes unit tests fail
-//          .placeholder(R.drawable.ic_image_gray_24dp)
-          .build()))
+        Coil.imageLoader(context)))
       .build()
 
     val adapter = MarkwonAdapter.createTextViewIsRoot(R.layout.adapter_node)


### PR DESCRIPTION
See discussion in #272 

This doesn't contain a fix, but a reproduction of the described issue. It's not exclusive to use in a RecyclerView, but also happens when injecting Markwon generated Spans into a simple TextView.