### PR TITLE
Resolves style issues in CustomTypefaceSpan

### DIFF
--- a/markwon-core/src/main/java/io/noties/markwon/core/spans/CustomTypefaceSpan.java
+++ b/markwon-core/src/main/java/io/noties/markwon/core/spans/CustomTypefaceSpan.java
@@ -23,34 +23,48 @@ public class CustomTypefaceSpan extends MetricAffectingSpan {
         return new CustomTypefaceSpan(typeface);
     }
 
+    @NonNull
+    public static CustomTypefaceSpan create(@NonNull Typeface typeface, boolean mergeStyles) {
+        return new CustomTypefaceSpan(typeface, mergeStyles);
+    }
+
     private final Typeface typeface;
 
+    private final boolean mergeStyles;
+
     public CustomTypefaceSpan(@NonNull Typeface typeface) {
+        this(typeface, false);
+    }
+
+    public CustomTypefaceSpan(@NonNull Typeface typeface, boolean mergeStyles) {
         this.typeface = typeface;
+        this.mergeStyles = mergeStyles;
+    }
+
+
+    @Override
+    public void updateMeasureState(@NonNull TextPaint paint) {
+        updatePaint(paint);
     }
 
     @Override
-    public void updateMeasureState(@NonNull TextPaint p) {
-        updatePaint(p);
-    }
-
-    @Override
-    public void updateDrawState(@NonNull TextPaint tp) {
-        updatePaint(tp);
+    public void updateDrawState(@NonNull TextPaint paint) {
+        updatePaint(paint);
     }
 
     private void updatePaint(@NonNull TextPaint paint) {
-        final Typeface old = paint.getTypeface();
-        final int oldStyle;
-        if (old == null) {
-            oldStyle = Typeface.NORMAL;
+        final Typeface oldTypeface = paint.getTypeface();
+        if (!mergeStyles ||
+                oldTypeface == null ||
+                oldTypeface.getStyle() == Typeface.NORMAL) {
+            paint.setTypeface(typeface);
         } else {
-            oldStyle = old.getStyle();
+            final int oldStyle = oldTypeface.getStyle();
+
+            @SuppressLint("WrongConstant") final int want = oldStyle | typeface.getStyle();
+            final Typeface styledTypeface = Typeface.create(typeface, want);
+
+            paint.setTypeface(styledTypeface);
         }
-
-        @SuppressLint("WrongConstant") final int want = oldStyle | typeface.getStyle();
-        final Typeface styledTypeface = Typeface.create(typeface, want);
-
-        paint.setTypeface(styledTypeface);
     }
 }

--- a/markwon-core/src/main/java/io/noties/markwon/core/spans/CustomTypefaceSpan.java
+++ b/markwon-core/src/main/java/io/noties/markwon/core/spans/CustomTypefaceSpan.java
@@ -1,5 +1,6 @@
 package io.noties.markwon.core.spans;
 
+import android.annotation.SuppressLint;
 import android.graphics.Typeface;
 import android.text.TextPaint;
 import android.text.style.MetricAffectingSpan;
@@ -34,11 +35,22 @@ public class CustomTypefaceSpan extends MetricAffectingSpan {
     }
 
     @Override
-    public void updateDrawState(TextPaint tp) {
+    public void updateDrawState(@NonNull TextPaint tp) {
         updatePaint(tp);
     }
 
     private void updatePaint(@NonNull TextPaint paint) {
-        paint.setTypeface(typeface);
+        final Typeface old = paint.getTypeface();
+        final int oldStyle;
+        if (old == null) {
+            oldStyle = Typeface.NORMAL;
+        } else {
+            oldStyle = old.getStyle();
+        }
+
+        @SuppressLint("WrongConstant") final int want = oldStyle | typeface.getStyle();
+        final Typeface styledTypeface = Typeface.create(typeface, want);
+
+        paint.setTypeface(styledTypeface);
     }
 }


### PR DESCRIPTION
When two or more `CustomTypefaceSpan` are applied on a same character
sequence, previous `TextPaint`'s style was not respected.

Example:
--------
**Strong Emphasis _strong emphasis and emphasis combined_**

Before the inner text will only have the font applied without respecting
that the outer text is strong.

Related  [bug report](https://issuetracker.google.com/issues/169658958) on Google: