### PR TITLE
startActivity() will not only cause ActivityNotFoundException.

### DIFF
--- a/markwon-core/src/main/java/io/noties/markwon/LinkResolverDef.java
+++ b/markwon-core/src/main/java/io/noties/markwon/LinkResolverDef.java
@@ -25,7 +25,9 @@ public class LinkResolverDef implements LinkResolver {
         try {
             context.startActivity(intent);
         } catch (ActivityNotFoundException e) {
-            Log.w("LinkResolverDef", "Actvity was not found for the link: '" + link + "'");
+            Log.w("LinkResolverDef", "Activity was not found for the link: '" + link + "'");
+        } catch (Exception e) {
+            Log.w("LinkResolverDef", e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Here is an example from Wear OS.

```
Fatal Exception: java.lang.SecurityException: Permission Denial: starting Intent { act=android.intent.action.VIEW dat=https://github.com/... cmp=com.google.android.wearable.app/com.google.android.clockwork.home.application.UriRedirectActivity (has extras) } from ProcessRecord{7282c83 3044:com.ryuunoakaihitomi.rebootmenu/u0a40} (pid=3044, uid=10040) requires com.google.android.wearable.READ_SETTINGS
       at android.os.Parcel.readException(Parcel.java:1684)
       at android.os.Parcel.readException(Parcel.java:1637)
       at android.app.ActivityManagerProxy.startActivity(ActivityManagerProxy.java:3101)
       at android.app.Instrumentation.execStartActivity(Instrumentation.java:1518)
       at android.app.Activity.startActivityForResult(Activity.java:4228)
       at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:676)
       at android.app.Activity.startActivityForResult(Activity.java:4186)
       at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:663)
       at android.app.Activity.startActivity(Activity.java:4525)
       at android.app.Activity.startActivity(Activity.java:4493)
       at android.content.ContextWrapper.startActivity(ContextWrapper.java:356)
       at io.noties.markwon.LinkResolverDef.resolve(LinkResolverDef.java:26)
```