### PR TITLE
HTML ordered lists initial position

### DIFF
--- a/app-sample/samples.json
+++ b/app-sample/samples.json
@@ -40,6 +40,19 @@
     ]
   },
   {
+    "javaClassName": "io.noties.markwon.app.samples.html.HtmlOrderedListNumbersSample",
+    "id": "20210201140502",
+    "title": "HTML Ordered list numbers",
+    "description": "",
+    "artifacts": [
+      "HTML"
+    ],
+    "tags": [
+      "rendering",
+      "html"
+    ]
+  },
+  {
     "javaClassName": "io.noties.markwon.app.samples.html.InspectHtmlTextSample",
     "id": "20210201140501",
     "title": "Inspect text",

--- a/app-sample/src/main/java/io/noties/markwon/app/samples/html/HtmlOrderedListNumbersSample.java
+++ b/app-sample/src/main/java/io/noties/markwon/app/samples/html/HtmlOrderedListNumbersSample.java
@@ -1,0 +1,35 @@
+package io.noties.markwon.app.samples.html;
+
+import io.noties.markwon.Markwon;
+import io.noties.markwon.app.sample.ui.MarkwonTextViewSample;
+import io.noties.markwon.html.HtmlPlugin;
+import io.noties.markwon.sample.annotations.MarkwonArtifact;
+import io.noties.markwon.sample.annotations.MarkwonSampleInfo;
+import io.noties.markwon.sample.annotations.Tag;
+
+@MarkwonSampleInfo(
+  id = "20210201140502",
+  title = "HTML Ordered list numbers",
+  artifacts = MarkwonArtifact.HTML,
+  tags = {Tag.rendering, Tag.html}
+)
+public class HtmlOrderedListNumbersSample extends MarkwonTextViewSample {
+  @Override
+  public void render() {
+    final String md = "# HTML Ordered lists\n\n" +
+      "<ol start=\"7\">" +
+      "    <li>July</li>\n" +
+      "    <li>August</li>\n" +
+      "    <li>September</li>\n" +
+      "    <li>October</li>\n" +
+      "    <li>November</li>\n" +
+      "    <li>December</li>\n" +
+      "</ol>\n" +
+      "";
+
+    final Markwon markwon = Markwon.builder(context)
+            .usePlugin(HtmlPlugin.create())
+            .build();
+    markwon.setMarkdown(textView, md);
+  }
+}

--- a/markwon-html/src/main/java/io/noties/markwon/html/tag/ListHandler.java
+++ b/markwon-html/src/main/java/io/noties/markwon/html/tag/ListHandler.java
@@ -19,6 +19,8 @@ import io.noties.markwon.html.TagHandler;
 
 public class ListHandler extends TagHandler {
 
+    private static final String START_KEY = "start";
+
     @Override
     public void handle(
             @NonNull MarkwonVisitor visitor,
@@ -41,7 +43,7 @@ public class ListHandler extends TagHandler {
         final RenderProps renderProps = visitor.renderProps();
         final SpanFactory spanFactory = configuration.spansFactory().get(ListItem.class);
 
-        int number = 1;
+        int number = Integer.parseInt(block.attributes().containsKey(START_KEY) ? block.attributes().get(START_KEY) : "1");
         final int bulletLevel = currentBulletListLevel(block);
 
         for (HtmlTag.Block child : block.children()) {


### PR DESCRIPTION
Fixes #381 missing initial values when processing html ordered lists

- Adds an example for html ordered lists to showcase the initial starting value being taken into account
- Takes the tag `start` attribute into account when creating the initial list _number_
 
| BEFORE | AFTER | 
| --- | --- |
|![before-markwon](https://user-images.githubusercontent.com/1848238/177406231-b1b511f2-e635-4f46-b6c9-dab065a2c664.png)|![after-markwon](https://user-images.githubusercontent.com/1848238/177406829-79a3f61d-16ef-4284-997a-837ee46c0f16.png)

