### PR TITLE
Bump Picasso to 2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ ext {
             'debug'                   : 'io.noties:debug:5.1.0',
             'adapt'                   : 'io.noties:adapt:2.2.0',
             'dagger'                  : "com.google.dagger:dagger:$daggerVersion",
-            'picasso'                 : 'com.squareup.picasso:picasso:2.71828',
+            'picasso'                 : 'com.squareup.picasso:picasso:2.8',
             'glide'                   : 'com.github.bumptech.glide:glide:4.11.0',
             'coil'                    : "io.coil-kt:coil:$coilVersion",
             'coil-base'               : "io.coil-kt:coil-base:$coilVersion",


### PR DESCRIPTION
Picasso 2.71828 is a support library dependent library and requires Jetifier in Android, update Picasso to 2.8.