### PR TITLE
Update StrikeHandler.java

### DIFF
--- a/markwon-html/src/main/java/io/noties/markwon/html/tag/StrikeHandler.java
+++ b/markwon-html/src/main/java/io/noties/markwon/html/tag/StrikeHandler.java
@@ -56,7 +56,7 @@ public class StrikeHandler extends TagHandler {
     @NonNull
     @Override
     public Collection<String> supportedTags() {
-        return Arrays.asList("s", "del");
+        return Arrays.asList("s", "del", "strike");
     }
 
     @Nullable


### PR DESCRIPTION
Add support for `<strike>` html tag.

[README.md](https://github.com/noties/Markwon/blob/master/README.md) for Markwon library says that 3 html tags are supported for strikethrough "Strike-through (`<s>`, `<strike>`, `<del>`). But currently `<strike>` html tag does nothing. This patch tries to add support for `<strike>` html tag.